### PR TITLE
logging - using longbok to define the logger

### DIFF
--- a/modules/library/README.md
+++ b/modules/library/README.md
@@ -1,0 +1,15 @@
+# Logging configuration
+
+Slf4j is used as a logging facade, and by default the logs will be redirected
+onto the standard output.
+
+If one need to tweak the log level, it can be done by modifying the
+`bootstrap.yml` file of the spring-boot application, e.g.:
+
+```
+logging.level:
+  org.springframework: DEBUG
+  org.hibernate.SQL: DEBUG
+  org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+```
+

--- a/modules/library/common-search/src/main/java/org/fao/geonet/common/search/ElasticSearchProxy.java
+++ b/modules/library/common-search/src/main/java/org/fao/geonet/common/search/ElasticSearchProxy.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.common.search.domain.Profile;
@@ -39,8 +40,6 @@ import org.fao.geonet.common.search.processor.impl.JsonUserAndSelectionAwareResp
 import org.fao.geonet.common.search.processor.impl.RssResponseProcessorImpl;
 import org.fao.geonet.common.search.processor.impl.XmlResponseProcessorImpl;
 import org.fao.geonet.common.search.processor.impl.XsltResponseProcessorImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -52,6 +51,7 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j(topic = "org.fao.geonet.searching")
 public class ElasticSearchProxy {
 
   public static final String[] validContentTypes = {
@@ -113,8 +113,6 @@ public class ElasticSearchProxy {
           GnMediaType.APPLICATION_DCAT2_XML_VALUE, "dcat",
           "dcat", "dcat"
       );
-
-  private static Logger LOGGER = LoggerFactory.getLogger("org.fao.geonet.searching");
 
   public ElasticSearchProxy() {
   }
@@ -280,7 +278,7 @@ public class ElasticSearchProxy {
         copyHeadersToConnection(request, connectionWithFinalHost);
 
         connectionWithFinalHost.setDoOutput(true);
-        LOGGER.debug(requestBody);
+        log.debug(requestBody);
         connectionWithFinalHost.getOutputStream().write(requestBody.getBytes(Constants.ENCODING));
 
         // connect to remote host
@@ -414,7 +412,7 @@ public class ElasticSearchProxy {
             Arrays.asList(new String[]{"accept-encoding"}));
 
         connectionWithFinalHost.setDoOutput(true);
-        LOGGER.debug(requestBody);
+        log.debug(requestBody);
         connectionWithFinalHost.getOutputStream().write(requestBody.getBytes(Constants.ENCODING));
 
         // connect to remote host

--- a/modules/services/ogc-api-records/service/src/main/java/org/fao/geonet/ogcapi/records/service/CollectionService.java
+++ b/modules/services/ogc-api-records/service/src/main/java/org/fao/geonet/ogcapi/records/service/CollectionService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.domain.UiSetting;
@@ -22,9 +23,8 @@ import org.springframework.stereotype.Service;
 
 
 @Service
+@Slf4j(topic = "org.fao.geonet.ogcapi.records")
 public class CollectionService {
-
-  private static Logger LOGGER = LoggerFactory.getLogger("org.fao.geonet.ogcapi.records");
 
   @Autowired
   private OgcApiConfiguration configuration;
@@ -108,7 +108,7 @@ public class CollectionService {
           sortbyValues.iterator().forEachRemaining(s -> sortables.add(s.get("sortBy").textValue()));
         }
       } catch (Exception ex) {
-        LOGGER.error(ex.getMessage(), ex);
+        log.error(ex.getMessage(), ex);
       }
     }
 


### PR DESCRIPTION
This is not a fundamental code change, as we let lombok define the static field for the logger instead of defining it explicitely in each classes, and we still make use of slf4j for logging purposes.

Tests:
* compilation / testsuite ok
* runtime test ok: modifying the bootstrap.yml to change the logging
  level actually changes the logging level at runtime in the console.