### PR TITLE
OGC API Record / Add WAR build mode.

### DIFF
--- a/modules/services/ogc-api-records/README.md
+++ b/modules/services/ogc-api-records/README.md
@@ -1,10 +1,15 @@
 # OGC API Record service
 
+## Build
+
 Build the OpenApi using `openapi-generator-maven-plugin`
 
 ```
 mvn clean compile
 ```
+
+
+## Start
 
 Check the `target/generate-sources` folder.
 
@@ -28,7 +33,7 @@ mvn process-resources
 ```
 
 
-Test the service:
+## Test the service
 
 ```shell script
 
@@ -82,8 +87,7 @@ curl 127.0.0.1:9991/collections/$firstCollection/items/$uuid \
 API also `f` URL parameter to set the output format eg. http://localhost:9991/collections?f=xml
 
 
-
-Start as a standalone module:
+## Start as standalone service
 
 ```shell script
 mvn package
@@ -91,4 +95,16 @@ SERVER_PORT=9901 java -Dspring.profiles.active=standalone -jar target/gn-ogc-api
 
 # With custom configuration
 SERVER_PORT=9901 java -Dspring.profiles.active=standalone  -Dspring.config.location=./config/ -jar target/gn-ogc-api-records.jar
+```
+
+
+## Start as WAR
+
+Use the `war` profile to build the WAR:
+
+```shell script
+cd modules/services/ogc-api-records/service
+mvn package -Pwar,-docker
+
+mvn jetty:run -Pwar -Dspring.profiles.active=standalone  -Dspring.config.location=./service/src/main/resources/
 ```

--- a/modules/services/ogc-api-records/service/pom.xml
+++ b/modules/services/ogc-api-records/service/pom.xml
@@ -17,7 +17,7 @@
   <artifactId>gn-ogc-api-records-service</artifactId>
   <name>OGC API Records service</name>
   <url>http://geonetwork-opensource.org</url>
-  <packaging>jar</packaging>
+  <packaging>${packaging.type}</packaging>
 
   <dependencies>
     <dependency>
@@ -107,6 +107,20 @@
               <artifactId>spring-boot-configuration-processor</artifactId>
             </exclude>
           </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.4.27.v20200227</version>
+        <configuration>
+          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <httpConnector>
+            <port>9999</port>
+          </httpConnector>
+          <stopKey>JETTY_TOP</stopKey>
+          <stopPort>9998</stopPort>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/services/ogc-api-records/service/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordWebApp.java
+++ b/modules/services/ogc-api-records/service/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordWebApp.java
@@ -1,0 +1,22 @@
+/**
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.fao.geonet.ogcapi.records;
+
+import org.fao.geonet.ogcapi.records.controller.CapabilitiesApiController;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication
+@Import({CapabilitiesApiController.class})
+@ComponentScan({"org.fao.geonet", "org.fao.geonet.domain"})
+@Configuration
+@EnableCaching
+public class OgcApiRecordWebApp extends SpringBootServletInitializer {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <spring-cloud.version>Hoxton.SR8</spring-cloud.version>
-    <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
+    <spring-boot.version>2.3.8.RELEASE</spring-boot.version>
     <spring-security-oauth2-core.version>5.3.2.RELEASE</spring-security-oauth2-core.version>
     <geonetwork.version>4.0.0-0</geonetwork.version>
     <jetty.version>9.4.27.v20200227</jetty.version>
@@ -37,7 +37,7 @@
     <camel.version>3.5.0</camel.version>
     <swagger.version>2.1.2</swagger.version>
     <joda-time.version>2.10.6</joda-time.version>
-    <jackson.version>2.11.3</jackson.version>
+    <jackson.version>2.11.4</jackson.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
         <artifactId>gn-cloud-standard-iso19139</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.geonetwork-opensource.cloud</groupId>
+        <artifactId>gn-ogc-api-records-service</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.geonetwork-opensource</groupId>
@@ -343,6 +348,28 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jar</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <packaging.type>jar</packaging.type>
+      </properties>
+    </profile>
+    <profile>
+      <id>war</id>
+      <properties>
+        <packaging.type>war</packaging.type>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
     <java.version>11</java.version>
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
+
+    <packaging.type>jar</packaging.type>
   </properties>
 
   <modules>
@@ -348,15 +350,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <packaging.type>jar</packaging.type>
-      </properties>
     </profile>
     <profile>
       <id>war</id>


### PR DESCRIPTION
Some users would like to continue using WAR instead of Spring boot JAR.

Add a profile to configure the packaging type `jar` is default but `war` can be used too. For now, only OGC API Record service is using this configurable packaging type.

`mvn jetty:run` can be used for testing the WAR file.
