### PR TITLE
common-view - stick to tailwindcss 2.x

### DIFF
--- a/modules/library/common-view/src/main/resources/xslt/core/themes/default/theme.xsl
+++ b/modules/library/common-view/src/main/resources/xslt/core/themes/default/theme.xsl
@@ -18,7 +18,7 @@
       <meta name="description" content=""/>
       <meta name="keywords" content=""/>
       <meta name="author" content=""/>
-      <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css"/>
+      <link rel="stylesheet" href="https://unpkg.com/tailwindcss@2.2.19/dist/tailwind.min.css"/>
       <!--Replace with your tailwind.css once created-->
       <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
             rel="stylesheet"/>


### PR DESCRIPTION
There is no dist/ subdirectory in more recent versions of tailwindcss (3.x at least), so sticking to 2.2.19, else the unpkg.com redirects to a non-existing resource.
