### PR TITLE
OGC API / DCAT converter / Avoid NPE when no topic 

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.index.model.dcat2.CatalogRecord;
 import org.fao.geonet.index.model.dcat2.Dataset;
@@ -158,7 +160,11 @@ public class DcatConverter {
               .collect(Collectors.toList()))
           // INSPIRE <dct:type rdf:resource="{$ResourceTypeCodelistUri}/{$ResourceType}"/>
           .modified(toDate(record.getChangeDate()))
-          .theme(record.getCodelists().get(topic).stream().map(t -> Subject.builder()
+          .theme(
+              Optional.ofNullable(record.getCodelists().get(topic))
+                  .map(Collection::stream)
+                  .orElseGet(Stream::empty)
+              .map(t -> Subject.builder()
               .skosConcept(SkosConcept.builder()
                   // TODO: rdf:resource="{$TopicCategoryCodelistUri}/{$TopicCategory}"
                   .prefLabel(t.getProperties().get(defaultText))

--- a/modules/services/ogc-api-records/README.md
+++ b/modules/services/ogc-api-records/README.md
@@ -188,3 +188,10 @@ mvn jetty:run -Pwar -Dspring.profiles.active=standalone  -Dspring.config.locatio
 ```
 
 
+## Known issues
+
+If the HTML page of an item return the following error 
+```
+org.xml.sax.SAXParseException; lineNumber: 28; columnNumber: 50; Invalid byte 2 of 3-byte UTF-8 sequence.
+```
+add `-Dfile.encoding=UTF-8`.


### PR DESCRIPTION
Even if topic category is mandatory from an ISO point of view, some records may not defined it.

Make the mapping more robust on this point and avoid

```

java.lang.NullPointerException: null
	at org.fao.geonet.index.converter.DcatConverter.convert(DcatConverter.java:156) ~[classes/:na]
	at org.fao.geonet.ogcapi.records.controller.ItemApiController.collectionsCollectionIdItemsRecordIdGetAsJsonLd(ItemApiController.java:291) ~[classes/:na]