### PR TITLE
OGC API Records / Use track total hits.

### DIFF
--- a/modules/library/common-search/src/main/java/org/fao/geonet/common/search/SearchConfiguration.java
+++ b/modules/library/common-search/src/main/java/org/fao/geonet/common/search/SearchConfiguration.java
@@ -30,6 +30,8 @@ public class SearchConfiguration {
 
   String queryBase;
 
+  Boolean trackTotalHits;
+
   List<String> sortables = new ArrayList<>();
 
   List<String> sources = new ArrayList<>();

--- a/modules/library/common-search/src/main/resources/application.yml
+++ b/modules/library/common-search/src/main/resources/application.yml
@@ -4,6 +4,7 @@ gn:
     # 'queryBase': '${any}',
     # Full text but more boost on title match
     queryBase: 'any:(${any}) resourceTitleObject.default:(${any})^2'
+    trackTotalHits: true
     scoreConfig: >
       {
         "boost": "5",
@@ -85,12 +86,14 @@ gn:
         mimeType: application/rdf+xml
         responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
         operations:
+          - items
           - item
       -
         name : dcat_turtle
         mimeType : text/turtle
         responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
         operations :
+          - items
           - item
 #      -
 #        name : iso19139

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/RecordsEsQueryBuilder.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/RecordsEsQueryBuilder.java
@@ -137,7 +137,7 @@ public class RecordsEsQueryBuilder {
     }
     boolQuery.filter(QueryBuilders.queryStringQuery(filterQueryString));
     sourceBuilder.query(boolQuery);
-
+    sourceBuilder.trackTotalHits(configuration.getTrackTotalHits());
     log.debug("OGC API query: {}", sourceBuilder.toString());
 
     return sourceBuilder.toString();

--- a/modules/services/ogc-api-records/src/test/resources/application.yml
+++ b/modules/services/ogc-api-records/src/test/resources/application.yml
@@ -21,6 +21,7 @@ gn:
     # 'queryBase': '${any}',
     # Full text but more boost on title match
     queryBase: 'any:(${any}) resourceTitleObject.default:(${any})^2'
+    trackTotalHits: true
     scoreConfig: >
       {
         "boost": "5",


### PR DESCRIPTION
For large catalogue, we may want to search on all index content. Adding track total hits to Elasticsearch query to not limit to 10k results.

![image](https://user-images.githubusercontent.com/1701393/190136857-23605874-b0f2-47b9-ada3-24d0fe926349.png)


Similar to https://github.com/geonetwork/core-geonetwork/pull/6482.