### PR TITLE
Update ES client to 7.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <geonetwork.version>4.0.0-0</geonetwork.version>
     <jetty.version>9.4.27.v20200227</jetty.version>
 
-    <elasticsearch.version>7.9.0</elasticsearch.version>
+    <elasticsearch.version>7.15.1</elasticsearch.version>
     <micrometer.version>1.5.5</micrometer.version>
     <camel.version>3.5.0</camel.version>
     <swagger.version>2.1.2</swagger.version>


### PR DESCRIPTION
This makes the ogc-api-records service compatible with GN 4.2.2.