### PR TITLE
georss - adding a simple endpoint accessible with a GET request

### DIFF
--- a/modules/services/searching/src/main/java/org/fao/geonet/searching/controller/MainSearchController.java
+++ b/modules/services/searching/src/main/java/org/fao/geonet/searching/controller/MainSearchController.java
@@ -60,4 +60,37 @@ public class MainSearchController {
           HttpEntity<String> httpEntity) throws Exception {
     proxy.search(httpSession, request, response, body, bucket);
   }
+
+  /**
+   * provides an API endpoint for a GeoRSS endpoint, also sorts the records
+   * by changeDate (descending), and limits the results to the first 10.
+   *
+   * @param bucket the bucket where to search
+   * @param httpSession the http session object
+   * @param request the HTTTP request object
+   * @param response the HTTP response object
+   * @param httpEntity the http entity object
+   * @throws Exception the exception being thrown.
+   */
+  @RequestMapping(value = "/search/records/rss.search",
+      method = {
+          RequestMethod.GET
+      })
+  @Produces(value = "application/xml")
+  @ResponseStatus(value = HttpStatus.OK)
+  @ResponseBody
+  public void rssSearch(
+          @RequestParam(defaultValue = Constants.Selection.DEFAULT_SELECTION_METADATA_BUCKET)
+          String bucket,
+          HttpSession httpSession,
+          HttpServletRequest request,
+          HttpServletResponse response,
+          HttpEntity<String> httpEntity) throws Exception {
+    String body;
+    body = "{\"from\": 0, \"size\": 10,\"query\": {\"query_string\": {\"query\": \"+isTemplate:n\"}"
+        + "}, \"sort\": [{ \"changeDate\": {\"order\": \"desc\", \"unmapped_type\" : \"date\" }}]}";
+    proxy.search(httpSession, request, response, body, bucket);
+  }
+
+
 }


### PR DESCRIPTION
Afaict, georchestra/geonetwork-microservices@0953b7215 is the only meaningful src commit that was present in the `geor-main` branch of https://github.com/georchestra/geonetwork-microservices and not present in this upstream repo. 

cf https://github.com/geonetwork/geonetwork-microservices/compare/main...georchestra:geonetwork-microservices:geor-main

having this upstreamed would allow the georchestra project buildbot to start building the searching and ogc-api-records jars from the same repository, instead of providing a badly outdated jar on https://packages.georchestra.org/bot/wars/geonetwork-microservices/

cf georchestra/datadir#271, cc @pmauduit @jahow @fvanderbiest @fgravin 