### PR TITLE
OGC API Records / DCAT / Fix validation for endpointUrl

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
@@ -489,7 +489,8 @@ public class DcatConverter {
         }).collect(Collectors.toList()));
 
     dataServiceBuilder.endpointUrl(
-        record.getLinks().stream().map(l -> l.getUrl().get(defaultText))
+        record.getLinks().stream().map(l ->
+            new RdfResource(null, l.getUrl().get(defaultText)))
             .collect(Collectors.toList()));
 
     dataServiceBuilder.servesDataset(


### PR DESCRIPTION
In DCATService, endpoint URL is a rdf:resource (not a string)

```xml
            <dcat:endpointURL rdf:resource="https://geo.api.vlaanderen.be/ad/wfs?service=WFS&amp;request=getcapabilities"/>
```

Also fix the dcat_turtle format error on service.

```
Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.RuntimeException: org.eclipse.rdf4j.rio.RDFParseException: unexpected attribute 'xsi:type' [line 159, column 198]] with root cause
org.eclipse.rdf4j.rio.RDFParseException: unexpected attribute 'xsi:type' [line 159, column 198]
```


Validation can be tested using https://www.itb.ec.europa.eu/shacl/dcat-ap/upload


```xml
<!--  Encoding before <dcat:endpointURL xsi:type="xs:string" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">https://geo.api.vlaanderen.be/GRB/wms</dcat:endpointURL>-->
            <dcat:endpointURL rdf:resource="https://geo.api.vlaanderen.be/GRB/wms"/>
        </dcat:DataService>
    </foaf:primaryTopic>
</dcat:CatalogRecord>
```