### PR TITLE
OGC API Records / Collection / Item view may return error

### DIFF
--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
@@ -21,7 +21,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -372,7 +371,7 @@ public class ItemApiController {
     }
 
     try {
-      String collectionFilter = collectionService.retrieveCollectionFilter(source);
+      String collectionFilter = collectionService.retrieveCollectionFilter(source, true);
       String query = recordsEsQueryBuilder.buildQuerySingleRecord(recordId, collectionFilter, null);
 
       String queryResponse = proxy.searchAndGetResult(request.getSession(), request, query, null);
@@ -470,7 +469,7 @@ public class ItemApiController {
       HttpServletRequest request,
       Source source,
       String type) throws Exception {
-    String collectionFilter = collectionService.retrieveCollectionFilter(source);
+    String collectionFilter = collectionService.retrieveCollectionFilter(source, true);
     String query = recordsEsQueryBuilder.buildQuerySingleRecord(recordId, collectionFilter, null);
 
     String queryResponse = proxy.searchAndGetResult(request.getSession(), request, query, null);
@@ -532,7 +531,7 @@ public class ItemApiController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Unable to find collection");
     }
 
-    String collectionFilter = collectionService.retrieveCollectionFilter(source);
+    String collectionFilter = collectionService.retrieveCollectionFilter(source, false);
     String query = recordsEsQueryBuilder
         .buildQuery(q, externalids, bbox,
             startindex, limit, collectionFilter, sortby,
@@ -603,7 +602,7 @@ public class ItemApiController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Unable to find collection");
     }
 
-    String collectionFilter = collectionService.retrieveCollectionFilter(source);
+    String collectionFilter = collectionService.retrieveCollectionFilter(source, false);
     String query = recordsEsQueryBuilder
         .buildQuery(q, externalids, bbox, startindex, limit, collectionFilter, sortby, null);
     EsSearchResults results = new EsSearchResults();

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/service/CollectionService.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/service/CollectionService.java
@@ -65,16 +65,18 @@ public class CollectionService {
   /**
    * Retrieves the ElasticSearch filter related to a collection.
    */
-  public String retrieveCollectionFilter(Source source) {
+  public String retrieveCollectionFilter(Source source, boolean escape) {
     String collectionFilter = "";
 
     if (source.getType() == SourceType.subportal) {
       collectionFilter = source.getFilter();
     } else if (source.getType() == SourceType.harvester) {
-      collectionFilter = String.format("+harvesterUuid:\\\"%s\\\"", source.getUuid());
+      collectionFilter = String.format("+harvesterUuid:\"%s\"", source.getUuid());
     }
 
-    return collectionFilter;
+    return escape
+        ? collectionFilter.replace("\"", "\\\"")
+        : collectionFilter;
   }
 
   /**


### PR DESCRIPTION
Problem is related to the query associated with the collection (it does not happen on the main collection).

 Eg. if the portal filter contains quote in the filter. Those were not escaped.

```
<message>Request processing failed; nested exception is java.lang.RuntimeException: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('0' (code 48)): was expecting comma to separate Object entries at [Source: (String)"{"from": 0, "size": 1, "query": {"query_string": {"query": "+_id:\"5e8864c4-35f8-5e8b-38e3-21be-954e-1579-bd3916db\" +harvesterUuid:"09ec5462-eb74-4209-9937-fabcf8c14efb" +isTemplate:n AND -indexingError:true"}}, "_source": {"includes": ["*"]}}"; line: 1, column: 135]</message>
<stackTrace>org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
```

When using the proxy, the query string must be escaped.


eg. for testing, create a portal with a filter like `+tag.default:"Lijst M&R INSPIRE"` 