### PR TITLE
feat: add config to specify custom urls in ogc-api-records

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfiguration.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfiguration.java
@@ -11,4 +11,6 @@ public interface FormatterConfiguration {
 
   /** for testing purposes. */
   void setLinkToLegacyGN4(Boolean linkToLegacyGN4);
+
+  void setLinkToCustomUrl(Boolean linkToCustomUrl);
 }

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfigurationImpl.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfigurationImpl.java
@@ -9,8 +9,14 @@ public class FormatterConfigurationImpl implements FormatterConfiguration {
   @Value("${gn.linkToLegacyGN4:false}")
   Boolean linkToLegacyGN4;
 
+  @Value("${gn.linkToCustomMetadataUrl:false}")
+  Boolean linkToCustomMetadataUrl;
+
   @Value("${gn.legacy.url}")
   String legacyUrl;
+
+  @Value("${gn.customMetadataUrl:}")
+  String customMetadataUrl;
 
   @Value("${gn.baseurl}")
   private String baseUrl;
@@ -25,6 +31,9 @@ public class FormatterConfigurationImpl implements FormatterConfiguration {
 
   @Override
   public String getSourceHomePage() {
+    if (linkToCustomMetadataUrl) {
+      return customMetadataUrl;
+    }
     if (linkToLegacyGN4) {
       return legacyUrl;
     }
@@ -40,6 +49,11 @@ public class FormatterConfigurationImpl implements FormatterConfiguration {
 
   @Override
   public String buildLandingPageLink(String metadataId) {
+    if (linkToCustomMetadataUrl) {
+      return String.format("%s/%s",
+          customMetadataUrl,
+          metadataId);
+    }
     if (linkToLegacyGN4) {
       return String.format("%s/srv/metadata/%s",
               legacyUrl,
@@ -54,5 +68,10 @@ public class FormatterConfigurationImpl implements FormatterConfiguration {
   @Override
   public void setLinkToLegacyGN4(Boolean linkToLegacyGN4) {
     this.linkToLegacyGN4 = linkToLegacyGN4;
+  }
+
+  @Override
+  public void setLinkToCustomUrl(Boolean linkToCustomMetadataUrl) {
+    this.linkToCustomMetadataUrl = linkToCustomMetadataUrl;
   }
 }

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfigurationImpl.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/FormatterConfigurationImpl.java
@@ -9,12 +9,20 @@ public class FormatterConfigurationImpl implements FormatterConfiguration {
   @Value("${gn.linkToLegacyGN4:false}")
   Boolean linkToLegacyGN4;
 
+  /**
+   * Used to enable customMetadataUrl in rss response.
+   */
   @Value("${gn.linkToCustomMetadataUrl:false}")
   Boolean linkToCustomMetadataUrl;
 
   @Value("${gn.legacy.url}")
   String legacyUrl;
 
+  /**
+   * Used to override link to metadata in rss response. It takes precedence over legacyUrl if both enabled.
+   * By default, the customMetadataUrl will redirect to host url with a trailing slash and followed by the metadata uuid. e.g: http://geonetwork.org/uuid
+   * You can customize it by redirect to another service (always followed by metadata uuid). e.g: http://my-other-service.com/uuid
+   */
   @Value("${gn.customMetadataUrl:}")
   String customMetadataUrl;
 

--- a/modules/library/common-search/src/test/java/org/fao/geonet/common/search/processor/impl/RssResponseProcessorImplTest.java
+++ b/modules/library/common-search/src/test/java/org/fao/geonet/common/search/processor/impl/RssResponseProcessorImplTest.java
@@ -142,7 +142,7 @@ public class RssResponseProcessorImplTest {
 			properties.setProperty("gn.baseurl", "http://gn5:8277/geonetwork");
 			properties.setProperty("gn.linkToLegacyGN4", "true");
 			properties.setProperty("gn.linkToCustomMetadataUrl", "false");
-      properties.setProperty("gn.customMetadataUrl", "http://gn:8277/custom");
+			properties.setProperty("gn.customMetadataUrl", "http://gn:8277/custom");
 			pspc.setProperties(properties);
 			return pspc;
 		}

--- a/modules/library/common-search/src/test/java/org/fao/geonet/common/search/processor/impl/RssResponseProcessorImplTest.java
+++ b/modules/library/common-search/src/test/java/org/fao/geonet/common/search/processor/impl/RssResponseProcessorImplTest.java
@@ -109,6 +109,27 @@ public class RssResponseProcessorImplTest {
 		assertFalse(diff.hasDifferences());
 	}
 
+  @Test
+  public void nominalOneItemToCustom() throws Exception {
+    formatterConfiguration.setLinkToLegacyGN4(true);
+    formatterConfiguration.setLinkToCustomUrl(true);
+
+    InputStream is = this.getClass().getResourceAsStream("es_flow.json");
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+    toTest.processResponse(null, is, os,	null, null, null);
+
+    InputStream expected = this.getClass().getResourceAsStream("one_item_feed_to_custom.xml");
+    String actual = os.toString(UTF_8);
+    Diff diff = DiffBuilder
+        .compare(Input.fromStream(expected))
+        .withTest(actual)
+        .withDifferenceEvaluator(EVALUATOR)
+        .ignoreWhitespace()
+        .build();
+    assertFalse(diff.hasDifferences());
+  }
+
 	@TestConfiguration
 	static class RssResponseProcessorImplTestConf {
 		@Bean
@@ -120,6 +141,8 @@ public class RssResponseProcessorImplTest {
 			properties.setProperty("gn.site.organization", "momorg");
 			properties.setProperty("gn.baseurl", "http://gn5:8277/geonetwork");
 			properties.setProperty("gn.linkToLegacyGN4", "true");
+			properties.setProperty("gn.linkToCustomMetadataUrl", "false");
+      properties.setProperty("gn.customMetadataUrl", "http://gn:8277/custom");
 			pspc.setProperties(properties);
 			return pspc;
 		}

--- a/modules/library/common-search/src/test/resources/org/fao/geonet/common/search/processor/impl/one_item_feed_to_custom.xml
+++ b/modules/library/common-search/src/test/resources/org/fao/geonet/common/search/processor/impl/one_item_feed_to_custom.xml
@@ -1,0 +1,13 @@
+<rss version="2.0">
+    <channel>
+        <title>the geonetwork momorg</title>
+        <link>http://gn4:8277/geonetwork</link>
+        <description>Search for datasets, services and maps...</description>
+        <item>
+            <title>multilingual</title>
+            <link>http://gn:8277/custom/6b21e3a6-5a53-433f-aba9-3f93ac2bdd74</link>
+            <author></author>
+            <guid isPermaLink="false">6b21e3a6-5a53-433f-aba9-3f93ac2bdd74</guid>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Custom urls can be specified with two config variables : 

- `linkToCustomMetadataUrl` boolean : Use custom url instead of legacyUrl or baseUrl
- `customMetadataUrl` string : url of the service. If none provided, url will be `/{metadata-uuid}`

