### PR TITLE
Index model / Add new nilReason property

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/model/gn/Link.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/model/gn/Link.java
@@ -27,4 +27,5 @@ public class Link {
   private String applicationProfile;
   private String group;
   private String mimeType;
+  private String nilReason;
 }


### PR DESCRIPTION
Added by https://github.com/geonetwork/core-geonetwork/pull/6869#pullrequestreview-1602028121


Error was:
```
29/8/2023 19:28:02com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: 
Unrecognized field "nilReason" (class org.fao.geonet.index.model.gn.Link), not marked as ignorable
 (8 known properties: "protocol", "applicationProfile", "nameObject", "descriptionObject", 
"mimeType", "group", "function", "urlObject"])
29/8/2023 19:28:02 at [Source: (StringReader); line: 1, column: 34563]
 (through reference chain: org.fao.geonet.index.model.gn.IndexRecord["link"]->
java.util.ArrayList[0]->org.fao.geonet.index.model.gn.Link["nilReason"])
```