### PR TITLE
OGCAPI - GeoJSON output improvements

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
@@ -316,7 +316,7 @@ public class DcatConverter {
     }
 
     // <dct:spatial rdf:parseType="Resource">
-    datasetBuilder.spatial(record.getGeometries().stream().map(g -> DctSpatial.builder()
+    datasetBuilder.spatial(record.getGeometriesAsJsonString().stream().map(g -> DctSpatial.builder()
         .location(DctLocation.builder().geometry(g).build()).build()).collect(
         Collectors.toList()));
 
@@ -470,7 +470,8 @@ public class DcatConverter {
               .getProperties().get(CommonField.key));
     }
 
-    dataServiceBuilder.spatial(record.getGeometries().stream().map(g -> DctSpatial.builder()
+    dataServiceBuilder.spatial(record.getGeometriesAsJsonString().stream()
+        .map(g -> DctSpatial.builder()
         .location(DctLocation.builder().geometry(g).build()).build()).collect(
         Collectors.toList()));
 

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/GeoJsonConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/GeoJsonConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
  * Index document to GeoJSON mapping.
  */
 @Component
-public class GeoJsonConverter {
+public class GeoJsonConverter implements IGeoJsonConverter {
 
   @Autowired
   FormatterConfiguration formatterConfiguration;
@@ -50,7 +50,7 @@ public class GeoJsonConverter {
         ObjectMapper objectMapper = JsonUtils.getObjectMapper();
 
         recordBuilder.geometry(objectMapper.readValue(
-            record.getGeometries().get(0),
+            record.getGeometriesAsJsonString().get(0),
             Geometry.class));
       } catch (Exception ex) {
         // TODO: Process the exception

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/IGeoJsonConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/IGeoJsonConverter.java
@@ -1,0 +1,7 @@
+package org.fao.geonet.index.converter;
+
+import org.fao.geonet.index.model.gn.IndexRecord;
+
+public interface IGeoJsonConverter {
+  Object convert(IndexRecord record);
+}

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/SchemaOrgConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/SchemaOrgConverter.java
@@ -246,7 +246,7 @@ public class SchemaOrgConverter {
     if (record.getGeometries().size() > 0) {
       ObjectNode spatialCoverage = root.putObject("spatialCoverage");
       ArrayNode geo = spatialCoverage.putArray("geo");
-      record.getGeometries().forEach(g -> {
+      record.getGeometriesAsJsonString().forEach(g -> {
         GeoJsonReader geoJsonReader = new GeoJsonReader();
         try {
           ObjectNode shape = createThing(null, Types.GeoShape, root);

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/SchemaOrgConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/SchemaOrgConverter.java
@@ -14,6 +14,7 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.index.model.gn.Contact;
 import org.fao.geonet.index.model.gn.IndexRecord;
@@ -35,6 +36,7 @@ import org.locationtech.jts.io.geojson.GeoJsonReader;
  *
  * <p>TODO: Add support to translation https://bib.schema.org/workTranslation
  */
+@Slf4j(topic = "org.fao.geonet.ogcapi.records")
 public class SchemaOrgConverter {
 
   public static Map<String, String> dateMapping = Map.ofEntries(
@@ -259,7 +261,7 @@ public class SchemaOrgConverter {
                   envelope.getMaxY(), envelope.getMaxX()));
           geo.add(shape);
         } catch (ParseException e) {
-          e.printStackTrace();
+          log.debug(e.getMessage(),e);
         }
       });
     }

--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/model/gn/LocationSerializer.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/model/gn/LocationSerializer.java
@@ -20,6 +20,7 @@ public class LocationSerializer extends JsonSerializer<List<Coordinate>> {
       JsonGenerator gen,
       SerializerProvider serializers)
       throws IOException {
+    gen.writeStartObject();
     gen.writeArrayFieldStart(IndexRecordFieldNames.location);
     coordinate.forEach(c -> {
       try {

--- a/modules/library/common-index-model/src/test/java/org/fao/geonet/index/model/gn/IndexRecordTest.java
+++ b/modules/library/common-index-model/src/test/java/org/fao/geonet/index/model/gn/IndexRecordTest.java
@@ -99,7 +99,7 @@ public class IndexRecordTest {
 
       Assert.assertEquals(
           "{\"type\":\"Polygon\",\"coordinates\":[[[-31.2684,27.6375],[-13.4198,27.6375],[-13.4198,66.5662],[-31.2684,66.5662],[-31.2684,27.6375]]]}",
-          record.getGeometries().get(0));
+          record.getGeometriesAsJsonString().get(0));
     } catch (JsonProcessingException e) {
       e.printStackTrace();
       Assert.fail();

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordApp.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordApp.java
@@ -5,6 +5,7 @@
 
 package org.fao.geonet.ogcapi.records;
 
+import org.fao.geonet.index.converter.GeoJsonConverter;
 import org.fao.geonet.ogcapi.records.controller.CapabilitiesApiController;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,6 +14,7 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -21,7 +23,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @SpringBootApplication
 @RefreshScope
 @Import({CapabilitiesApiController.class})
-@ComponentScan({"org.fao.geonet", "org.fao.geonet.domain"})
+@ComponentScan(
+    value = {"org.fao.geonet", "org.fao.geonet.domain"}, excludeFilters =
+    {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GeoJsonConverter.class)}
+)
 @Configuration
 @EnableCaching
 public class OgcApiRecordApp {
@@ -30,9 +35,9 @@ public class OgcApiRecordApp {
     SpringApplication.run(OgcApiRecordApp.class, args);
   }
 
-
   /**
    * Configure CORS to allow all connections.
+   *
    * @return CORS configuration.
    */
   @Bean

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordWebApp.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/OgcApiRecordWebApp.java
@@ -5,18 +5,33 @@
 
 package org.fao.geonet.ogcapi.records;
 
+import org.fao.geonet.index.converter.GeoJsonConverter;
 import org.fao.geonet.ogcapi.records.controller.CapabilitiesApiController;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 
+
+/**
+ * We remove the "GeoJsonConverter" from the scanned components so this will app will use the
+ * "OgcApiGeoJsonConverter".
+ */
 @SpringBootApplication
 @Import({CapabilitiesApiController.class})
-@ComponentScan({"org.fao.geonet", "org.fao.geonet.domain"})
+@ComponentScan(
+    value = {"org.fao.geonet", "org.fao.geonet.domain"}, excludeFilters =
+    {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GeoJsonConverter.class)}
+)
+//@ComponentScan(
+//    value = {"org.fao.geonet", "org.fao.geonet.domain"}
+//)
 @Configuration
 @EnableCaching
 public class OgcApiRecordWebApp extends SpringBootServletInitializer {
+
+
 }

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
@@ -293,7 +293,6 @@ public class ItemApiController {
           || mediaType.equals(GnMediaType.APPLICATION_JSON_LD)
           || mediaType.equals(MediaType.APPLICATION_JSON)
           || mediaType.equals(GnMediaType.APPLICATION_RDF_XML);
-          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML);
 
       return collectionsCollectionIdItemsGetInternal(
           query,
@@ -503,7 +502,6 @@ public class ItemApiController {
       Query requestQuery,
       HttpServletRequest request,
       boolean allSourceFields) {
-      HttpServletRequest request, boolean allSourceFields) {
 
     Source source = collectionService.retrieveSourceForCollection(requestQuery.getCollectionId());
 

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
@@ -276,7 +276,10 @@ public class ItemApiController {
 
       boolean allSourceFields =
           mediaType.equals(GnMediaType.APPLICATION_DCAT2_XML)
-          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML);
+          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
+          || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)
+          || mediaType.equals(GnMediaType.APPLICATION_JSON_LD)
+          || mediaType.equals(MediaType.APPLICATION_JSON);
 
       return collectionsCollectionIdItemsGetInternal(
           collectionId, bbox, datetime, limit, startindex, type, q, externalids, sortby,
@@ -493,7 +496,8 @@ public class ItemApiController {
       List<String> q,
       List<String> externalids,
       List<String> sortby,
-      HttpServletRequest request, boolean allSourceFields) {
+      HttpServletRequest request,
+      boolean allSourceFields) {
 
     Source source = collectionService.retrieveSourceForCollection(collectionId);
 

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
@@ -60,7 +60,7 @@ public class OgcApiGeoJsonConverter implements IGeoJsonConverter {
 
     result.setId(collectionInfo.getId());
     result.setProperty("title", collectionInfo.getTitle());
-    result.setProperty("description", collectionInfo.getTitle());
+    result.setProperty("description", collectionInfo.getDescription());
     result.setProperty("language", collectionInfo.getLanguage());
     result.setProperty("languages", collectionInfo.getLanguages());
     result.setProperty("created", collectionInfo.getCreated());

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
@@ -1,0 +1,94 @@
+/**
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.fao.geonet.ogcapi.records.converter;
+
+import java.util.ArrayList;
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.index.converter.IGeoJsonConverter;
+import org.fao.geonet.index.model.gn.IndexRecord;
+import org.fao.geonet.ogcapi.records.controller.model.CollectionInfo;
+import org.fao.geonet.ogcapi.records.model.GeoJsonPolygon;
+import org.fao.geonet.ogcapi.records.model.OgcApiTime;
+import org.fao.geonet.ogcapi.records.util.ElasticIndexJson2CollectionInfo;
+import org.fao.geonet.repository.MetadataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converts an elastic JSON Index Record into an OGCAPI compliant GeoJSON record.
+ */
+@Component
+public class OgcApiGeoJsonConverter implements IGeoJsonConverter {
+
+  @Autowired
+  ElasticIndexJson2CollectionInfo elasticIndexJson2CollectionInfo;
+
+  @Autowired
+  MetadataRepository metadataRepository;
+
+  /**
+   * converts an IndexRecord (elastic Index Json Record) to a OgcApiGeoJsonRecord.
+   * @param elasticIndexJsonRecord IndexRecord from Elastic
+   * @return converted to OgcApiGeoJsonRecord.
+   */
+  public OgcApiGeoJsonRecord convert(IndexRecord elasticIndexJsonRecord) {
+    var result = new OgcApiGeoJsonRecord();
+
+    injectCollectionInfoProperties(result, elasticIndexJsonRecord);
+
+    result.setConformsTo(new ArrayList<>());
+    result.getConformsTo()
+        .add("http://www.opengis.net/spec/ogcapi-records-1/1.0/req/record-core");
+
+    result.setProperty("gn-elastic-index-record", elasticIndexJsonRecord);
+
+    Metadata metadataRecord = metadataRepository.findOneByUuid(
+        elasticIndexJsonRecord.getMetadataIdentifier());
+
+    result.setProperty("gn-record-xml", metadataRecord.getData());
+    return result;
+  }
+
+  private void injectCollectionInfoProperties(OgcApiGeoJsonRecord result,
+      IndexRecord elasticIndexJsonRecord) {
+    var collectionInfo = new CollectionInfo();
+    elasticIndexJson2CollectionInfo.injectLinkedServiceRecordInfo(collectionInfo,
+        elasticIndexJsonRecord);
+
+    result.setId(collectionInfo.getId());
+    result.setProperty("title", collectionInfo.getTitle());
+    result.setProperty("description", collectionInfo.getTitle());
+    result.setProperty("language", collectionInfo.getLanguage());
+    result.setProperty("languages", collectionInfo.getLanguages());
+    result.setProperty("created", collectionInfo.getCreated());
+    result.setProperty("updated", collectionInfo.getUpdated());
+    result.setProperty("type", collectionInfo.getType());
+    result.setProperty("keywords", collectionInfo.getKeywords());
+    result.setProperty("themes", collectionInfo.getThemes());
+    result.setProperty("resourceLanguages", collectionInfo.getRecordLanguages());
+    result.setProperty("contacts", collectionInfo.getContacts());
+    result.setProperty("license", collectionInfo.getLicense());
+    result.setProperty("rights", collectionInfo.getRights());
+
+    if (collectionInfo.getExtent() != null
+        && collectionInfo.getExtent().getSpatial() != null
+        && collectionInfo.getExtent().getSpatial().getBbox() != null
+        && !collectionInfo.getExtent().getSpatial().getBbox().isEmpty()) {
+      result.setGeometry(
+          GeoJsonPolygon.fromBBox(collectionInfo.getExtent().getSpatial().getBbox()));
+    }
+
+    if (collectionInfo.getExtent() != null
+        && collectionInfo.getExtent().getTemporal() != null
+        && collectionInfo.getExtent().getTemporal().getInterval() != null
+        && !collectionInfo.getExtent().getTemporal().getInterval().isEmpty()) {
+      var time = new OgcApiTime();
+      time.setInterval(collectionInfo.getExtent().getTemporal().getInterval());
+      result.setTime(time);
+    }
+  }
+
+}

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonConverter.java
@@ -49,6 +49,11 @@ public class OgcApiGeoJsonConverter implements IGeoJsonConverter {
         elasticIndexJsonRecord.getMetadataIdentifier());
 
     result.setProperty("gn-record-xml", metadataRecord.getData());
+
+    if (elasticIndexJsonRecord.getResourceType() != null
+        && !elasticIndexJsonRecord.getResourceType().isEmpty()) {
+      result.setType(elasticIndexJsonRecord.getResourceType().get(0));
+    }
     return result;
   }
 

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonRecord.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/converter/OgcApiGeoJsonRecord.java
@@ -1,0 +1,132 @@
+/**
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.fao.geonet.ogcapi.records.converter;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+import org.fao.geonet.ogcapi.records.model.GeoJsonPolygon;
+import org.fao.geonet.ogcapi.records.model.OgcApiLink;
+import org.fao.geonet.ogcapi.records.model.OgcApiLinkTemplate;
+import org.fao.geonet.ogcapi.records.model.OgcApiTime;
+
+/**
+ * See OGCAPI spec - Table 8. (8.2.2. Core properties) Core properties related to the catalog
+ * record.
+ */
+@Data
+@SuperBuilder
+@AllArgsConstructor
+public class OgcApiGeoJsonRecord {
+
+  /**
+   * A unique record identifier assigned by the server.
+   */
+  private String id;
+
+  /**
+   * A spatial extent associated with the resource described by this record. Can be null if there is
+   * no associated spatial extent.
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private GeoJsonPolygon geometry;
+
+  /**
+   * The extensions/conformance classes used in this record.
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private List<String> conformsTo;
+
+  /**
+   * A temporal extent associated with the resource described by this record. Can be null if there
+   * is no associated temporal extent.
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private OgcApiTime time;
+
+  /**
+   * A list of links related to this record.
+   */
+  @JsonProperty(value = "links")
+  @JsonInclude(Include.NON_EMPTY)
+  private List<OgcApiLink> links;
+
+  /**
+   * A list of link templates related to this record.
+   */
+  @JsonProperty(value = "linkTemplates")
+  @JsonInclude(Include.NON_EMPTY)
+  private List<OgcApiLinkTemplate> linkTemplates;
+
+  private String type = "Feature";
+
+
+  /**
+   * Extra properties.  Can have any properties you want.  However, OGCAPI-Records defines;
+   *
+   * <p>properties.created  - The date this record was created in the server.
+   *
+   * <p>properties.updated  - The  most recent date on which the record was changed.
+   *
+   * <p>properties.language  - The language used for
+   * textual values (i.e. titles, descriptions, etc.) of this record.
+   *
+   * <p>properties.languages  - The list of other languages in which this record is available.
+   *
+   * <p>properties.type  - The nature or genre of the resource described by this record.
+   *
+   * <p>properties.title  - A human-readable name given to the resource described by this record.
+   *
+   * <p>properties.description  - A free-text description of the resource described by this record.
+   *
+   * <p>properties.keywords  - A list of free-form keywords or tags associated with the resource
+   * described by this record.
+   *
+   * <p>properties.themes  - A knowledge organization system used to classify the resource
+   * described by this resource.
+   *
+   * <p>properties.resourceLanguages  - The list of languages in which the resource described
+   * by this record can be retrieved.
+   *
+   * <p>properties.externalIds  - One or more identifiers, assigned by an
+   * external entity, for the resource described by this record.
+   *
+   * <p>properties.formats  - A list of
+   * available distributions for the resource described by this record.
+   *
+   * <p>properties.contacts  - A list of contacts qualified by their role(s) in association to
+   * the record or the resource described by this record.
+   *
+   * <p>properties.license  - The legal provisions under which the resource
+   * described by this record is made available. NOTE: special format (see spec)
+   *
+   * <p>properties.rights  - A statement that concerns all rights not addressed by the license
+   * such as a copyright statement.
+   */
+  @JsonProperty(value = "properties")
+  private Map<String, Object> properties;
+
+  public OgcApiGeoJsonRecord() {
+    properties = new LinkedHashMap<>();
+  }
+
+  /**
+   * sets a named property in the #properties object.
+   * @param propertyName which property to set?
+   * @param value value of the property.
+   */
+  public void setProperty(String propertyName, Object value) {
+    if (value != null) {
+      properties.put(propertyName, value);
+    }
+  }
+}

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/GeoJsonPolygon.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/GeoJsonPolygon.java
@@ -1,0 +1,53 @@
+/**
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.fao.geonet.ogcapi.records.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * represents a GeoJSON polygon.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeoJsonPolygon {
+
+  public String type = "Polygon";
+
+  public List<List<List<Double>>> coordinates = new ArrayList<>();
+
+  /**
+   * builder to construct a polygon from a bounding box.
+   * @param bbox bounding box - xmin, ymin, xmax, ymax
+   * @return GeoJsonPolygon with a rectangular polygon representing the bounding box.
+   */
+  public static GeoJsonPolygon fromBBox(List<Double> bbox) {
+    var result = new GeoJsonPolygon();
+    result.addCoord(bbox.get(0), bbox.get(1)); //xmin, ymin
+    result.addCoord(bbox.get(2), bbox.get(1)); //xmax, ymin
+    result.addCoord(bbox.get(2), bbox.get(3)); //xmax, ymax
+    result.addCoord(bbox.get(0), bbox.get(3)); //xmin, ymax
+    result.addCoord(bbox.get(0), bbox.get(1)); //xmin, ymin
+    return result;
+  }
+
+  /**
+   * helper function to add a point to the polygon.
+   * @param c1 coordinate 1 (x)
+   * @param c2 coordinate 2 (y)
+   */
+  public void addCoord(Double c1, Double c2) {
+    if (coordinates.isEmpty()) {
+      coordinates.add(new ArrayList<>());
+    }
+    coordinates.get(0).add(Arrays.asList(c1, c2));
+  }
+}

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/OgcApiLinkTemplate.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/OgcApiLinkTemplate.java
@@ -1,0 +1,39 @@
+/**
+ * (c) 2024 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+
+package org.fao.geonet.ogcapi.records.model;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * OGCAPI link Template. https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/linkTemplate.yaml
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OgcApiLinkTemplate extends OgcApiLink {
+
+  /**
+   * Supplies a resolvable URI to a remote resource (or resource fragment). example:
+   * http://data.example.com/buildings/(building-id}
+   */
+  private String uriTemplate;
+
+  /**
+   * The base URI to which the variable name can be appended to retrieve the definition of the
+   * variable as a JSON Schema fragment. format: uri
+   */
+  private String varBase;
+
+  /**
+   * This object contains one key per substitution variable in the templated URL.  Each key defines
+   * the schema of one substitution variable using a JSON Schema fragment and can thus include
+   * things like the data type of the variable, enumerations, minimum values, maximum values, etc.
+   */
+  private Map<String, JsonProperty> variables;
+}

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/OgcApiTime.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/model/OgcApiTime.java
@@ -1,0 +1,72 @@
+package org.fao.geonet.ogcapi.records.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * OGCAPI Time. https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/time.yaml
+ *
+ * <p>see 8.2.7. Temporal information (ogcapi records spec).
+ */
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OgcApiTime {
+
+  /**
+   * type: string. pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private String date;
+
+  /**
+   * type: string. pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private String timestamp;
+
+  /**
+   * Interval. minItems: 2 maxItems: 2 items: oneOf: - type: string pattern:
+   * "^\\d{4}-\\d{2}-\\d{2}$" - type: string
+   * pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+   * - type: string enum: - ".."
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private List<String> interval;
+
+  /**
+   * Minimum time period resolvable in the dataset, as an ISO 8601 duration. example: - 'P1D'
+   */
+  @JsonInclude(Include.NON_EMPTY)
+  private String resolution;
+
+  /**
+   * Set the interval given a set of interval datetimes (1st=start,2nd=end).
+   * If the intervals are null, use "..".  See ogcapi spec for intervals.
+   * @param interval list of datetime objects.  Should be exactly 2, can be nulls.
+   */
+  public void setInterval(List<String> interval) {
+    if (interval.size() != 2) {
+      return;
+    }
+    this.interval = new ArrayList<>();
+
+    if (interval.get(0) != null) {
+      this.interval.add(interval.get(0));
+    } else {
+      this.interval.add("..");
+    }
+    if (interval.get(1) != null) {
+      this.interval.add(interval.get(1));
+    } else {
+      this.interval.add("..");
+    }
+  }
+}

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/service/RecordService.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/service/RecordService.java
@@ -161,7 +161,7 @@ public class RecordService {
     JsonNode totalValue =
         "json".equals(type)
             ? actualObj.get("hits").get("total").get("value")
-            : actualObj.get("size");
+            : actualObj.get("numberMatched");
 
     if ((totalValue == null) || (totalValue.intValue() == 0)) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/ElasticIndexJson2CollectionInfo.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/ElasticIndexJson2CollectionInfo.java
@@ -64,7 +64,9 @@ public class ElasticIndexJson2CollectionInfo {
       return;
     }
 
-    set(getId(collectionInfo,indexRecord),collectionInfo,"id");
+    if (collectionInfo.getId() == null) {
+      set(getId(collectionInfo, indexRecord), collectionInfo, "id");
+    }
 
     set(getTitle(collectionInfo, indexRecord), collectionInfo, "title");
     set(getDescription(collectionInfo, indexRecord), collectionInfo, "description");

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/ElasticIndexJson2CollectionInfo.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/ElasticIndexJson2CollectionInfo.java
@@ -64,6 +64,8 @@ public class ElasticIndexJson2CollectionInfo {
       return;
     }
 
+    set(getId(collectionInfo,indexRecord),collectionInfo,"id");
+
     set(getTitle(collectionInfo, indexRecord), collectionInfo, "title");
     set(getDescription(collectionInfo, indexRecord), collectionInfo, "description");
 
@@ -169,6 +171,14 @@ public class ElasticIndexJson2CollectionInfo {
     return null;
   }
 
+  //process id
+  private String getId(CollectionInfo collectionInfo,
+      IndexRecord indexRecord) {
+    var id = indexRecord.getMetadataIdentifier();
+    return id;
+  }
+
+
   //process main language
   private OgcApiLanguage getLanguage(CollectionInfo collectionInfo,
       IndexRecord indexRecord) {
@@ -240,10 +250,10 @@ public class ElasticIndexJson2CollectionInfo {
   private OgcApiTemporalExtent getTemporalExtent(IndexRecord indexRecord) {
     OgcApiTemporalExtent temporalExtent = null;
     var myTemporalExtent = indexRecord.getResourceTemporalExtentDateRange();
-    if (myTemporalExtent != null || myTemporalExtent.isEmpty()) {
+    if (myTemporalExtent == null || myTemporalExtent.isEmpty()) {
       myTemporalExtent = indexRecord.getResourceTemporalDateRange();
     }
-    if (myTemporalExtent != null || myTemporalExtent.isEmpty()) {
+    if (myTemporalExtent != null &&  !myTemporalExtent.isEmpty()) {
       temporalExtent = OgcApiTemporalExtent.fromGnIndexRecord(myTemporalExtent.get(0));
     }
     return temporalExtent;
@@ -254,14 +264,8 @@ public class ElasticIndexJson2CollectionInfo {
     OgcApiSpatialExtent spatialExtent = null;
     var mySpatialExtent = indexRecord.getGeometries();
     if (mySpatialExtent != null && !mySpatialExtent.isEmpty()) {
-      Map<String, Object> map = null;
-      try {
-        map = new org.codehaus.jackson.map.ObjectMapper().readValue(mySpatialExtent.get(0),
-            TypeFactory.mapType(HashMap.class, String.class, Object.class));
-      } catch (IOException e) {
-        return null;
-      }
-      spatialExtent = OgcApiSpatialExtent.fromGnIndexRecord(map);
+      spatialExtent = OgcApiSpatialExtent.fromGnIndexRecord(
+          (Map<String, Object>) mySpatialExtent.get(0));
     }
     return spatialExtent;
   }

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/RecordsEsQueryBuilder.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/RecordsEsQueryBuilder.java
@@ -43,7 +43,8 @@ public class RecordsEsQueryBuilder {
       "contact", "contactForResource",
       "cl_status",
       "edit", "tag", "changeDate",
-      "createDate", "mainLanguage", "geom", "formats");
+      "createDate", "mainLanguage", "geom", "formats",
+      "resourceTemporalDateRange","resourceTemporalExtentDateRange");
 
   private static final String SORT_BY_SEPARATOR = ",";
 


### PR DESCRIPTION
This PR improves the GeoJSON output to be more compliant with the OGCAPI-Records specification.

1. I've added all the Table 8 and Table 9 attributes, with the format the same as in the specification.
2. I also added a `gn-elastic-index-record` property that has the IndexRecord (Elastic JSON Index document) in it
3. I also added a `gn-record-xml` property that has the metadata record's XML text in it.

NOTE:
1. I noticed that there was a lot of "JSON Strings" in the IndexRecord.  For example;
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/0e0221e5-331e-4491-abff-0f66a7e6b1a9">
Its now represented as a normal json object:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/0807b1e7-c196-4835-bb4b-04df9dafc9a9">

2. The `geometries` property was in a "JSON Strings", but I've converted it to a normal JSON object.  I also added a `getGeometriesAsJsonString()` method to access it as normal.  I also added a `geometriesAsJsonString` property to the JSON with the old format.

3. I was a little worried about changing the GeoJSON output too much (other things might depend on it).  So, I created an `IGeoJsonConverter` interface with two implementation.  `GeoJsonConverter` (the old one) and `OgcApiGeoJsonConverter` (the new one).

4. I noticed a few bugs, which I've fixed.

5. I've added a few more `OgcApi*` model objects.
 
6. Here is an example of the new GeoJSON output - based on one of the "iso19139" Geonetwork sample records.
    * notice the `gn-elastic-index-record`  (all the elastic index properties)
    * notice `gn-record-xml` (underlying metadata iso19139 xml)
    * notice that the defined properties (table 8 & 9, below) are in the proper format (as best I could do the conversion)
[items.geojson](https://github.com/user-attachments/files/17400959/items.geojson.txt)


Table 8 & 9 from the spec:
![image](https://github.com/user-attachments/assets/2713d96a-2111-46b2-8a45-fe0d084d33a4)
![image](https://github.com/user-attachments/assets/dcdf338b-c880-487a-965d-c2c5e5efdbba)
