### PR TITLE
Change GeoJSON to be used for f=json, add f=elastic-json for old format

### DIFF
--- a/modules/library/common-search/src/main/java/org/fao/geonet/common/search/GnMediaType.java
+++ b/modules/library/common-search/src/main/java/org/fao/geonet/common/search/GnMediaType.java
@@ -43,6 +43,9 @@ public class GnMediaType extends MimeType {
   public static final String APPLICATION_GEOJSON_VALUE = "application/geo+json";
   public static final MediaType APPLICATION_GEOJSON;
 
+  public static final String APPLICATION_ELASTICJSON_VALUE = "application/elastic+json";
+  public static final MediaType APPLICATION_ELASTICJSON;
+
 
   static {
     TEXT_TURTLE = new MediaType("text", "turtle");
@@ -55,5 +58,6 @@ public class GnMediaType extends MimeType {
     APPLICATION_GN_XML = new MediaType("application", "gn+xml");
     APPLICATION_JSON_LD = new MediaType("application", "ld+json");
     APPLICATION_GEOJSON = new MediaType("application", "geo+json");
+    APPLICATION_ELASTICJSON = new MediaType("application", "elastic+json");
   }
 }

--- a/modules/library/common-search/src/main/java/org/fao/geonet/common/search/GnMediaType.java
+++ b/modules/library/common-search/src/main/java/org/fao/geonet/common/search/GnMediaType.java
@@ -43,7 +43,7 @@ public class GnMediaType extends MimeType {
   public static final String APPLICATION_GEOJSON_VALUE = "application/geo+json";
   public static final MediaType APPLICATION_GEOJSON;
 
-  public static final String APPLICATION_ELASTICJSON_VALUE = "application/elastic+json";
+  public static final String APPLICATION_ELASTICJSON_VALUE = "application/gnindex+json";
   public static final MediaType APPLICATION_ELASTICJSON;
 
 
@@ -58,6 +58,6 @@ public class GnMediaType extends MimeType {
     APPLICATION_GN_XML = new MediaType("application", "gn+xml");
     APPLICATION_JSON_LD = new MediaType("application", "ld+json");
     APPLICATION_GEOJSON = new MediaType("application", "geo+json");
-    APPLICATION_ELASTICJSON = new MediaType("application", "elastic+json");
+    APPLICATION_ELASTICJSON = new MediaType("application", "gnindex+json");
   }
 }

--- a/modules/library/common-search/src/main/resources/application.yml
+++ b/modules/library/common-search/src/main/resources/application.yml
@@ -60,7 +60,7 @@ gn:
       -
         name: json
         mimeType: application/json
-        responseProcessor: JsonUserAndSelectionAwareResponseProcessorImpl
+        responseProcessor: GeoJsonResponseProcessorImpl
         operations:
           - root
           - conformance
@@ -111,6 +111,12 @@ gn:
         responseProcessor: RssResponseProcessorImpl
         operations:
           - items
+      - name : elastic-json
+        mimeType : application/elastic+json
+        responseProcessor : JsonUserAndSelectionAwareResponseProcessorImpl
+        operations :
+          - items
+          - item
       -
         name : geojson
         mimeType : application/geo+json

--- a/modules/library/common-search/src/main/resources/application.yml
+++ b/modules/library/common-search/src/main/resources/application.yml
@@ -111,8 +111,8 @@ gn:
         responseProcessor: RssResponseProcessorImpl
         operations:
           - items
-      - name : elastic-json
-        mimeType : application/elastic+json
+      - name : gnindex-json
+        mimeType : application/gnindex+json
         responseProcessor : JsonUserAndSelectionAwareResponseProcessorImpl
         operations :
           - items

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
@@ -134,7 +134,8 @@ public class ItemApiController {
           GnMediaType.APPLICATION_RDF_XML_VALUE,
           GnMediaType.APPLICATION_DCAT2_XML_VALUE,
           GnMediaType.TEXT_TURTLE_VALUE,
-          GnMediaType.APPLICATION_GEOJSON_VALUE})
+          GnMediaType.APPLICATION_GEOJSON_VALUE,
+          GnMediaType.APPLICATION_ELASTICJSON_VALUE})
   @ResponseStatus(HttpStatus.OK)
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Describe a collection item.")
@@ -216,6 +217,7 @@ public class ItemApiController {
           GnMediaType.APPLICATION_DCAT2_XML_VALUE,
           MediaType.TEXT_HTML_VALUE,
           GnMediaType.APPLICATION_GEOJSON_VALUE,
+          GnMediaType.APPLICATION_ELASTICJSON_VALUE
       })
   @ResponseStatus(HttpStatus.OK)
   @ApiResponses(value = {
@@ -284,11 +286,20 @@ public class ItemApiController {
         || mediaType.equals(GnMediaType.APPLICATION_DCAT2_XML)
         || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
         || mediaType.equals(MediaType.APPLICATION_RSS_XML)
-        || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)) {
+        || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)
+        || mediaType.equals(GnMediaType.APPLICATION_ELASTICJSON)
+       ) {
 
       boolean allSourceFields =
           mediaType.equals(GnMediaType.APPLICATION_DCAT2_XML)
               || mediaType.equals(GnMediaType.APPLICATION_RDF_XML);
+          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
+          || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)
+          || mediaType.equals(GnMediaType.APPLICATION_JSON_LD)
+          || mediaType.equals(MediaType.APPLICATION_JSON)
+          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
+          || mediaType.equals(GnMediaType.APPLICATION_ELASTICJSON);
+
 
       return collectionsCollectionIdItemsGetInternal(
           query,

--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/controller/ItemApiController.java
@@ -287,12 +287,11 @@ public class ItemApiController {
         || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
         || mediaType.equals(MediaType.APPLICATION_RSS_XML)
         || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)
-        || mediaType.equals(GnMediaType.APPLICATION_ELASTICJSON)
-       ) {
+        || mediaType.equals(GnMediaType.APPLICATION_ELASTICJSON)) {
 
       boolean allSourceFields =
           mediaType.equals(GnMediaType.APPLICATION_DCAT2_XML)
-              || mediaType.equals(GnMediaType.APPLICATION_RDF_XML);
+          || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
           || mediaType.equals(GnMediaType.APPLICATION_RDF_XML)
           || mediaType.equals(GnMediaType.APPLICATION_GEOJSON)
           || mediaType.equals(GnMediaType.APPLICATION_JSON_LD)


### PR DESCRIPTION
The OGCAPI-Records spec says to use GeoJSON for `/collections/<collectionId>/items` and  `/collections/<collectionId>/items/<itemId>` responses.

This PR changes the current default (the underlying Elastic Search results) and, instead, uses GeoJSON.

I've also added a `f=elastic-json` for the old behaviour.  This shouldn't be used, and will be removes in the future.  However, I don't want to remove it now since people might be relying on it, and its useful for debugging.

Also, see  https://github.com/geonetwork/geonetwork-microservices/pull/118 for improvements to the GeoJSON output.