### PR TITLE
OGC API Records / Items / DCAT / NPE fix

### DIFF
--- a/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
+++ b/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java
@@ -123,9 +123,13 @@ public class DcatConverter {
     Dataset dcatDataset = null;
     DataService dcatService = null;
     try {
+      JsonNode indexSource = doc.get(IndexRecordFieldNames.source);
+
       IndexRecord record = new ObjectMapper()
           .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-          .readValue(doc.get(IndexRecordFieldNames.source).toString(), IndexRecord.class);
+          .readValue(
+              indexSource != null ? indexSource.toString() :
+              doc.get("properties").get("gn-elastic-index-record").toString(), IndexRecord.class);
 
       String recordIdentifier = record.getMetadataIdentifier();
       String recordUri = formatterConfiguration.buildLandingPageLink(


### PR DESCRIPTION
Fix NPE on DCAT item response eg.
http://localhost:9901/collections/main/items/f946d4e0-710b-11dc-83f9-000086f6a62e?f=dcat

```
2024-11-19 11:15:29.659 ERROR 547670 --- [nio-9901-exec-1] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.RuntimeException: java.lang.NullPointerException] with root cause

java.lang.NullPointerException: null
	at org.fao.geonet.index.converter.DcatConverter.convert(DcatConverter.java:128) ~[classes/:na]
	at org.fao.geonet.ogcapi.records.controller.ItemApiController.collectionsCollectionIdItemsRecordIdGetAsJsonLd(ItemApiController.java:365) ~[classes/:na]
	at org.fao.geonet.ogcapi.records.controller.ItemApiController.collectionsCollectionIdItemsRecordIdGet(ItemApiController.java:191) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190) ~[spring-web-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138) ~[spring-web-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:105) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:878) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:792) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1040) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:943) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc-5.2.12.RELEASE.jar:5.2.12.RELEASE]
	a
```

DCAT conversion is for now based on Elasticsearch index document which is properly returned for search but not for the items operation with now the new GeoJSON document with `doc.get("properties").get("gn-elastic-index-record")` which can be used for the conversion.

DCAT will be better supported with formatters https://github.com/geonetwork/geonetwork/issues/72 but for 4.4.6, this is relevant to be fixed.

Related to
https://github.com/geonetwork/geonetwork-microservices/pull/118