### PR TITLE
fix: protect against NPE in CollectionInfoBuilder

### DIFF
--- a/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/CollectionInfoBuilder.java
+++ b/modules/services/ogc-api-records/src/main/java/org/fao/geonet/ogcapi/records/util/CollectionInfoBuilder.java
@@ -78,7 +78,7 @@ public class CollectionInfoBuilder {
     CollectionInfo collectionInfo = new CollectionInfo();
 
     collectionInfo.setId(name);
-    String label = source.getLabel(language);
+    String label = Optional.ofNullable(source.getLabel(language)).orElse("");
     // The source label may contain a description
     // eg. "INSPIRE|Data sets and services for the environment"
     String[] titleAndDescription = label.split("\\|");


### PR DESCRIPTION
In case of missing translations on virtual CSW, there is a risk to raise a `NullPointerException` because `label` will be `null`. Preventing this by using an empty string instead.

Tests: `./mvnw clean test` is fine, `verify` is not because of https://github.com/geonetwork/geonetwork-microservices/issues/128